### PR TITLE
Verify Docker's DCO before starting any build.

### DIFF
--- a/github/comments.go
+++ b/github/comments.go
@@ -1,0 +1,59 @@
+package github
+
+import (
+	"fmt"
+	"strconv"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/crosbymichael/octokat"
+)
+
+func (g GitHub) addDCOUnsignedComment(repo octokat.Repo, pr *octokat.PullRequest, content *pullRequestContent) error {
+	comment := `Can you please sign your commits following these rules:
+https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work
+The easiest way to do this is to amend the last commit:
+~~~console
+`
+	comment += fmt.Sprintf("$ git clone -b %q %s %s\n", pr.Head.Ref, pr.Head.Repo.SSHURL, "somewhere")
+	comment += "$ cd somewhere\n"
+
+	if pr.Commits > 1 {
+		comment += fmt.Sprintf("$ git rebase -i HEAD~%d\n", pr.Commits)
+		comment += "editor opens\nchange each 'pick' to 'edit'\nsave the file and quit\n"
+	}
+
+	comment += "$ git commit --amend -s --no-edit\n"
+	if pr.Commits > 1 {
+		comment += "$ git rebase --continue # and repeat the amend for each commit\n"
+	}
+
+	comment += "$ git push -f\n"
+	comment += `~~~
+This will update the existing PR, so you do not need to open a new one.
+`
+
+	return g.addUniqueComment(repo, strconv.Itoa(pr.ID), comment, "sign your commits", content)
+}
+
+func (g GitHub) removeDCOUnsignedComment(repo octokat.Repo, pr *octokat.PullRequest, content *pullRequestContent) error {
+	if c := content.FindComment("sign your commits"); c != nil {
+		return g.Client().RemoveComment(repo, c.Id)
+	}
+
+	return nil
+}
+
+func (g GitHub) addUniqueComment(repo octokat.Repo, prNum, comment, commentType string, content *pullRequestContent) error {
+	// check if we already made the comment
+	if content.AlreadyCommented(commentType) {
+		return nil
+	}
+
+	// add the comment because we must not have already made it
+	if _, err := g.Client().AddComment(repo, prNum, comment); err != nil {
+		return err
+	}
+
+	log.Infof("Would have added comment about %q PR %s", commentType, prNum)
+	return nil
+}

--- a/github/dco.go
+++ b/github/dco.go
@@ -1,0 +1,80 @@
+package github
+
+import (
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/crosbymichael/octokat"
+)
+
+func (g GitHub) DcoVerified(prHook *octokat.PullRequestHook) (bool, error) {
+	// we only want the prs that are opened
+	if !prHook.IsOpened() {
+		return false, nil
+	}
+
+	// get the PR
+	pr := prHook.PullRequest
+	repo := getRepo(prHook.Repo)
+
+	content, err := g.getPullRequestContent(repo, prHook.Number)
+	if err != nil {
+		return false, err
+	}
+
+	// we only want apply labels
+	// to opened pull requests
+	var labels []string
+
+	//check if it's a proposal
+	isProposal := strings.Contains(strings.ToLower(pr.Title), "proposal")
+	switch {
+	case isProposal:
+		labels = []string{"status/1-needs-design-review"}
+	case content.IsDocsOnly():
+		labels = []string{"status/3-needs-docs-review"}
+	default:
+		labels = []string{"status/0-needs-triage"}
+	}
+
+	//add labels if there are any
+	if len(labels) > 0 {
+		log.Debugf("Adding labels %#v to pr %d", labels, prHook.Number)
+
+		if err := g.addLabel(repo, prHook.Number, labels...); err != nil {
+			return false, err
+		}
+
+		log.Infof("Added labels %#v to pr %d", labels, prHook.Number)
+	}
+
+	var verified bool
+	if content.CommitsSigned() {
+		if err := g.toggleLabels(repo, prHook.Number, "dco/no", "dco/yes"); err != nil {
+			return false, err
+		}
+
+		if err := g.successStatus(repo, pr.Head.Sha, "docker-dco", "All commits signed"); err != nil {
+			return false, err
+		}
+
+		verified = true
+	} else {
+		if err := g.toggleLabels(repo, prHook.Number, "dco/yes", "dco/no"); err != nil {
+			return false, err
+		}
+
+		if err := g.failureStatus(repo, pr.Head.Sha, "docker-dco", "Some commits without signature", "https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work"); err != nil {
+			return false, err
+		}
+	}
+
+	return verified, nil
+}
+
+func getRepo(repo *octokat.Repository) octokat.Repo {
+	return octokat.Repo{
+		Name:     repo.Name,
+		UserName: repo.Owner.Login,
+	}
+}

--- a/github/github.go
+++ b/github/github.go
@@ -1,0 +1,13 @@
+package github
+
+import "github.com/crosbymichael/octokat"
+
+type GitHub struct {
+	AuthToken string
+}
+
+func (g GitHub) Client() *octokat.Client {
+	gh := octokat.NewClient()
+	gh = gh.WithToken(g.AuthToken)
+	return gh
+}

--- a/github/labels.go
+++ b/github/labels.go
@@ -1,0 +1,33 @@
+package github
+
+import "github.com/crosbymichael/octokat"
+
+func (g GitHub) toggleLabels(repo octokat.Repo, issueNum int, labelToRemove, labelToAdd string) error {
+	if err := g.removeLabel(repo, issueNum, labelToRemove); err != nil {
+		return err
+	}
+	if err := g.addLabel(repo, issueNum, labelToAdd); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (g GitHub) addLabel(repo octokat.Repo, issueNum int, labels ...string) error {
+	issue := octokat.Issue{
+		Number: issueNum,
+	}
+
+	return g.Client().ApplyLabel(repo, &issue, labels)
+}
+
+func (g GitHub) removeLabel(repo octokat.Repo, issueNum int, labels ...string) error {
+	issue := octokat.Issue{
+		Number: issueNum,
+	}
+
+	for _, label := range labels {
+		return g.Client().RemoveLabel(repo, &issue, label)
+	}
+
+	return nil
+}

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -1,0 +1,94 @@
+package github
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/crosbymichael/octokat"
+)
+
+var (
+	dcoRegex = regexp.MustCompile("(?m)(Docker-DCO-1.1-)?Signed-off-by: ([^<]+) <([^<>@]+@[^<>]+)>( \\(github: ([a-zA-Z0-9][a-zA-Z0-9-]+)\\))?")
+)
+
+type pullRequestContent struct {
+	files   []*octokat.PullRequestFile
+	commits []octokat.Commit
+}
+
+func (p *pullRequestContent) IsDocsOnly() bool {
+	if len(p.files) == 0 {
+		return false
+	}
+
+	for _, f := range p.files {
+		if !strings.HasSuffix(f.FileName, ".md") || !strings.HasPrefix(f.FileName, "docs") {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (p *pullRequestContent) CommitsSigned() bool {
+	if len(p.commits) == 0 {
+		return true
+	}
+
+	for _, c := range p.commits {
+		if !dcoRegex.MatchString(c.Commit.Message) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (g *GitHub) getPullRequestContent(repo octokat.Repo, prId int) (*pullRequestContent, error) {
+	var (
+		errs    []error
+		wg      sync.WaitGroup
+		commits []octokat.Commit
+		files   []*octokat.PullRequestFile
+	)
+
+	n := strconv.Itoa(prId)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		var err error
+		commits, err = g.Client().Commits(repo, n, nil)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		var err error
+		files, err = g.Client().PullRequestFiles(repo, n, nil)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}()
+
+	wg.Wait()
+
+	if len(errs) > 0 {
+		b := bytes.NewBufferString("")
+		for _, e := range errs {
+			b.WriteString(e.Error())
+		}
+
+		return nil, errors.New(b.String())
+	}
+
+	return &pullRequestContent{files, commits}, nil
+}

--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -58,3 +58,55 @@ func TestFilesAreDocs(t *testing.T) {
 		}
 	}
 }
+
+func TestAlreadyCommented(t *testing.T) {
+	cases := []struct {
+		login string
+		body  string
+		exp   bool
+	}{
+		{
+			"calavera",
+			"sign your commits",
+			false,
+		},
+		{
+			"calavera",
+			":+1:",
+			false,
+		},
+		{
+			"gordontheturtle",
+			"rebase your commits",
+			false,
+		},
+		{
+			"gordontheturtle",
+			"sign your commits",
+			true,
+		},
+	}
+
+	for _, c := range cases {
+		comments := []octokat.Comment{
+			octokat.Comment{
+				User: octokat.User{
+					Login: c.login,
+				},
+				Body: c.body,
+			},
+		}
+
+		pr := &pullRequestContent{comments: comments}
+		if done := pr.AlreadyCommented("sign your commits"); done != c.exp {
+			t.Fatalf("Expected commented %v, but was %v for user %s and body %s\n", c.exp, done, c.login, c.body)
+		}
+
+		comment := pr.FindComment("sign your commits")
+		found := comment != nil
+
+		if found != c.exp {
+			t.Fatalf("Expected found %v, but was %v for user %s and body %s\n", c.exp, found, c.login, c.body)
+		}
+	}
+}

--- a/github/pull_request_test.go
+++ b/github/pull_request_test.go
@@ -1,0 +1,60 @@
+package github
+
+import (
+	"testing"
+
+	"github.com/crosbymichael/octokat"
+)
+
+func TestCommitsAreSigned(t *testing.T) {
+	cases := map[string]bool{
+		"":                                                                                                   false,
+		"Signed-off-by:":                                                                                     false,
+		"Signed-off-by: David Calavera <david.calavera@gmail.com>":                                           true,
+		"\n\nSigned-off-by: David Calavera <david.calavera@gmail.com>\n\n":                                   true,
+		"\n\nDocker-DCO-1.1-Signed-off-by: David Calavera <david.calavera@gmail.com> (github: calavera)\n\n": true,
+	}
+
+	for message, valid := range cases {
+		commits := []octokat.Commit{
+			octokat.Commit{
+				Commit: &octokat.CommitCommit{
+					Message: message,
+				},
+			},
+		}
+
+		pr := &pullRequestContent{commits: commits}
+		s := pr.CommitsSigned()
+
+		if s != valid {
+			t.Fatalf("expected %v, was %v, for: %s\n", valid, s, message)
+		}
+	}
+}
+
+func TestFilesAreDocs(t *testing.T) {
+	cases := map[string]bool{
+		"":                 false,
+		"file.txt":         false,
+		"file.md":          false,
+		"docs/file.txt":    false,
+		"docs/file.md":     true,
+		"docs/hub/file.md": true,
+	}
+
+	for filePath, valid := range cases {
+		files := []*octokat.PullRequestFile{
+			&octokat.PullRequestFile{
+				FileName: filePath,
+			},
+		}
+
+		pr := &pullRequestContent{files: files}
+		s := pr.IsDocsOnly()
+
+		if s != valid {
+			t.Fatalf("expected %v, was %v, for: %s\n", valid, s, filePath)
+		}
+	}
+}

--- a/github/status.go
+++ b/github/status.go
@@ -1,0 +1,22 @@
+package github
+
+import "github.com/crosbymichael/octokat"
+
+func (g GitHub) successStatus(repo octokat.Repo, sha, context, description string) error {
+	_, err := g.Client().SetStatus(repo, sha, &octokat.StatusOptions{
+		State:       "success",
+		Context:     context,
+		Description: description,
+	})
+	return err
+}
+
+func (g GitHub) failureStatus(repo octokat.Repo, sha, context, description, targetUrl string) error {
+	_, err := g.Client().SetStatus(repo, sha, &octokat.StatusOptions{
+		State:       "failure",
+		Context:     context,
+		Description: description,
+		URL:         targetUrl,
+	})
+	return err
+}


### PR DESCRIPTION
This moves the DCO verification before any builds starts. This prevents us from building any code that doesn't comply with Docker's DCO.

- TODO:

- [x] Add labels about PR status.
- [x] Add DCO labels.
- [x] Add PR status.
- [x] Add comment with help.