### PR TITLE
Do not toggle labels when the label to add is already set.

### DIFF
--- a/github/labels.go
+++ b/github/labels.go
@@ -7,12 +7,20 @@ import (
 )
 
 func (g GitHub) toggleLabels(repo octokat.Repo, issueNum int, labelToRemove, labelToAdd string) error {
-	if err := g.removeLabel(repo, issueNum, labelToRemove); err != nil {
+	exist, err := g.labelExist(repo, issueNum, labelToAdd)
+	if err != nil {
 		return err
 	}
-	if err := g.addLabel(repo, issueNum, labelToAdd); err != nil {
-		return err
+
+	if !exist {
+		if err := g.removeLabel(repo, issueNum, labelToRemove); err != nil {
+			return err
+		}
+		if err := g.addLabel(repo, issueNum, labelToAdd); err != nil {
+			return err
+		}
 	}
+
 	return nil
 }
 
@@ -36,4 +44,23 @@ func (g GitHub) removeLabel(repo octokat.Repo, issueNum int, labels ...string) e
 	}
 
 	return nil
+}
+
+func (g GitHub) labelExist(repo octokat.Repo, issueNum int, label string) (bool, error) {
+	i, err := g.Client().Issue(repo, issueNum, &octokat.Options{})
+	if err != nil {
+		return false, err
+	}
+
+	if i.Labels == nil || len(i.Labels) == 0 {
+		return false, nil
+	}
+
+	for _, l := range i.Labels {
+		if l.Name == label {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
This prevents sending consecutive events saying "Added dco/yes, removed dco/no".

Signed-off-by: David Calavera <david.calavera@gmail.com>