### PR TITLE
Add label windows when changes are only for windows.

### DIFF
--- a/github/dco.go
+++ b/github/dco.go
@@ -41,7 +41,9 @@ func (g GitHub) DcoVerified(prHook *octokat.PullRequestHook) (bool, error) {
 	default:
 		labels = []string{"status/0-needs-triage"}
 	}
-	if strings.Contains(strings.ToLower(pr.Title), "windows") || strings.Contains(strings.ToLower(pr.Body), "windows") {
+	if strings.Contains(strings.ToLower(pr.Title), "windows") ||
+		strings.Contains(strings.ToLower(pr.Body), "windows") ||
+		content.OnlyWindows() {
 		labels = append(labels, "os/windows")
 	}
 

--- a/github/pull_request.go
+++ b/github/pull_request.go
@@ -68,6 +68,21 @@ func (p *pullRequestContent) FindComment(commentType, user string) *octokat.Comm
 	return nil
 }
 
+func (p *pullRequestContent) OnlyWindows() bool {
+	var windows bool
+	var linux bool
+
+	for _, f := range p.files {
+		if strings.HasPrefix(f.FileName, "_windows.go") {
+			windows = true
+		} else if strings.HasPrefix(f.FileName, "_linux.go") {
+			linux = true
+		}
+	}
+
+	return windows && !linux
+}
+
 func (g *GitHub) getContent(repo octokat.Repo, id int, isPR bool) (*pullRequestContent, error) {
 	var (
 		files    []*octokat.PullRequestFile


### PR DESCRIPTION
Do not add the label when there are linux and windows changes.

/cc @jfrazelle

Signed-off-by: David Calavera <david.calavera@gmail.com>