### PR TITLE
Remove comments parsing looking for "windows"

### DIFF
--- a/github/issue.go
+++ b/github/issue.go
@@ -42,7 +42,6 @@ func (g GitHub) LabelIssueComment(issueHook *octokat.IssueHook) error {
 		"#dibs":    "status/claimed",
 		"#claimed": "status/claimed",
 		"#mine":    "status/claimed",
-		"windows":  "os/windows",
 	}
 
 	repo := getRepo(issueHook.Repo)


### PR DESCRIPTION
https://github.com/docker/docker/pull/13542

Everytime you type `windows` it adds the `os/windows` label, hope the small fix is ok :)
I think it's working on PR and issue cause for GitHub they are the same and you receive the hook regardless if it's a pr or an issue (I'm 99.99% sure so not totally eheh)

Signed-off-by: Antonio Murdaca <me@runcom.ninja>